### PR TITLE
Use new v1 search API endpoint

### DIFF
--- a/src/app/pages/app-list/app-list.component.ts
+++ b/src/app/pages/app-list/app-list.component.ts
@@ -129,7 +129,7 @@ export class AppListComponent implements OnInit {
     this.seoService.setPageMetadata('Search results—Linux Apps on Flathub',
       'Search applications published on Flathub', this.getFlathubMetaImage());
 
-    this.linuxStoreApiService.getAppsByKeyword(searchKeyword)
+    this.linuxStoreApiService.getAppsBySearchQuery(searchKeyword)
       .subscribe(apps => { this.apps = apps; });
   }
 


### PR DESCRIPTION
We have to investigate how strict redissearch matching, because typing not complete or exact name of application may result in returning list of all packages, or some random query. Example:

https://flathub.openshift.gnome.org/api/v1/apps/search/spotif